### PR TITLE
Player model v3 poikilos patch 1

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -45,7 +45,6 @@ ts_furniture.sit = function(name, pos)
 		default.player_set_animation(player, "stand", 30)
 	else
 		if player_model_version == "default_character_v3" then
-			-- next line may make player underground in versions < 0.5.0-dev
 			pos.y = pos.y - 0.6
 		end
 		player:moveto(pos)

--- a/init.lua
+++ b/init.lua
@@ -3,6 +3,18 @@ ts_furniture = {}
 -- If true, you can sit on chairs and benches, when right-click them.
 ts_furniture.enable_sitting = true
 
+local valid_player_model_versions =  {
+	default_character_v1 = true,  -- ignored
+	default_character_v2 = true,
+	default_character_v3 = true,
+}
+local player_model_version = "default_character_v2"
+
+if minetest.get_modpath("player_api") ~= nil then
+	player_model_version = "default_character_v3"
+end
+
+
 
 -- The following code is from "Get Comfortable [cozy]" (by everamzah; published under WTFPL).
 -- Thomas S. modified it, so that it can be used in this mod
@@ -32,6 +44,10 @@ ts_furniture.sit = function(name, pos)
 		default.player_attached[name] = false
 		default.player_set_animation(player, "stand", 30)
 	else
+		if player_model_version == "default_character_v3" then
+			-- next line may make player underground in versions < 0.5.0-dev
+			pos.y = pos.y - 0.6
+		end
 		player:moveto(pos)
 		player:set_eye_offset({ x = 0, y = -7, z = 2 }, { x = 0, y = 0, z = 0 })
 		player:set_physics_override(0, 0, 0)


### PR DESCRIPTION
The player hovers above the chair by only about .1 at first, but after looking around the player settles back down to the correct position. I'm not sure how to fix this. If I change my line to pos.y = pos.y - 0.7 the position is correct at first, but later falls through (due to the -.1 shift mentioned earlier), so I thought floating then settling down is less noticeable. I could use help though.