### PR TITLE
Do not register globalstep if cozy mod active

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -6,7 +6,7 @@ ts_furniture.enable_sitting = minetest.settings:get_bool("ts_furniture.enable_si
 -- Used for localization
 local S = minetest.get_translator("ts_furniture")
 
-if ts_furniture.enable_sitting then
+if ts_furniture.enable_sitting and not minetest.get_modpath('cozy') then
     -- The following code is from "Get Comfortable [cozy]" (by everamzah; published under WTFPL).
     -- Thomas S. modified it, so that it can be used in this mod
     minetest.register_globalstep(function(dtime)


### PR DESCRIPTION
As reported in #4 the golbalstep is not necessary in case the cozy mod is installed together with ts_furniture because does the same.