### PR TITLE
ignore group 'tree'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -185,7 +185,8 @@ end
 
 local ignore_groups = {
 	["wood"] = true,
-	["stone"] = true
+	["stone"] = true,
+	["tree"] = true
 }
 
 function ts_furniture.register_furniture(recipe, description, tiles)


### PR DESCRIPTION
some ethereal chairs are otherwise added to group:tree which seems not correct